### PR TITLE
Replace references to zimserver with ZimWiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ main
 .vscode
 .idea
 library
-zimwiki
+ZimWiki

--- a/LICENSE
+++ b/LICENSE
@@ -290,7 +290,7 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    ZimServer
+    ZimWiki
     Copyright (C) 2020  Jojii
 
     This program is free software; you can redistribute it and/or modify

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
 	go mod download
-	go build -o zimwiki
+	go build -o ZimWiki
 
 default: build
 
@@ -14,26 +14,26 @@ test:
 	go test
 
 man: build
-	./zimwiki --help-man | man -l -
+	./ZimWiki --help-man | man -l -
 
 run:
-	./zimwiki
+	./ZimWiki
 
 debug: build
-	./zimwiki
+	./ZimWiki
 
 install:
-	@if ! test -f zimwiki;then echo 'run "make build" first'; exit 1; fi
+	@if ! test -f ZimWiki;then echo 'run "make build" first'; exit 1; fi
 
 ifneq ($(shell id -u), 0)
 	@echo "You must be root to perform this action."
 	@exit 1
 endif
 	@mkdir -p /usr/local/share/man/man8
-	cp zimwiki /usr/bin/zimwiki
-	/usr/bin/zimwiki --help-man > zimwiki.1
-	install -Dm644 zimwiki.1 /usr/share/man/man8/zimwiki.8
-	@rm zimwiki.1
+	cp ZimWiki /usr/bin/ZimWiki
+	/usr/bin/ZimWiki --help-man > ZimWiki.1
+	install -Dm644 ZimWiki.1 /usr/share/man/man8/ZimWiki.8
+	@rm ZimWiki.1
 	@echo Installed successfully!
 
 uninstall:
@@ -41,11 +41,11 @@ ifneq ($(shell id -u), 0)
 	@echo "You must be root to perform this action."
 	@exit 1
 endif
-	rm /usr/bin/zimwiki
-	rm -f /usr/share/man/man8/zimwiki.8
+	rm /usr/bin/ZimWiki
+	rm -f /usr/share/man/man8/ZimWiki.8
 	@echo Uninstalled successfully!
 
 clean:
-	rm -f zimwiki.1
-	rm -f zimwiki
+	rm -f ZimWiki.1
+	rm -f ZimWiki
 	rm -f main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZimServer
+# ZimWiki
 A modern zim fileserver which can handle multiple zim files by serving a beautiful Wiki website. It is a lightweight and performant replacement for kiwix-serve and can handle many big wiki archives (zim files).
 
 # Screenshots
@@ -32,7 +32,7 @@ A modern zim fileserver which can handle multiple zim files by serving a beautif
  
 
 # Installation
-- Install go and compile it using `go build -o zimserver`
+- Install go and compile it using `go build -o ZimWiki`
 or
 - Download the latest release
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.jojii.de/jojii/zimserver
+module git.jojii.de/jojii/ZimWiki
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.jojii.de/jojii/ZimWiki
+module github.com/JojiiOfficial/ZimWiki
 
 go 1.14
 

--- a/handlers/data.go
+++ b/handlers/data.go
@@ -1,6 +1,6 @@
 package handlers
 
-import "git.jojii.de/jojii/zimserver/zim"
+import "git.jojii.de/jojii/ZimWiki/zim"
 
 // HandlerData data for handler funcs
 type HandlerData struct {

--- a/handlers/data.go
+++ b/handlers/data.go
@@ -1,6 +1,6 @@
 package handlers
 
-import "git.jojii.de/jojii/ZimWiki/zim"
+import "github.com/JojiiOfficial/ZimWiki/zim"
 
 // HandlerData data for handler funcs
 type HandlerData struct {

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"git.jojii.de/jojii/ZimWiki/zim"
+	"github.com/JojiiOfficial/ZimWiki/zim"
 )
 
 // Index handle index route

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"git.jojii.de/jojii/zimserver/zim"
+	"git.jojii.de/jojii/ZimWiki/zim"
 )
 
 // Index handle index route

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"git.jojii.de/jojii/ZimWiki/zim"
+	"github.com/JojiiOfficial/ZimWiki/zim"
 	"github.com/gorilla/mux"
 
 	log "github.com/sirupsen/logrus"

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"git.jojii.de/jojii/zimserver/zim"
+	"git.jojii.de/jojii/ZimWiki/zim"
 	"github.com/gorilla/mux"
 
 	log "github.com/sirupsen/logrus"

--- a/handlers/wiki.go
+++ b/handlers/wiki.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"git.jojii.de/jojii/zimserver/zim"
+	"git.jojii.de/jojii/ZimWiki/zim"
 	gzim "github.com/tim-st/go-zim"
 )
 

--- a/handlers/wiki.go
+++ b/handlers/wiki.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"git.jojii.de/jojii/ZimWiki/zim"
+	"github.com/JojiiOfficial/ZimWiki/zim"
 	gzim "github.com/tim-st/go-zim"
 )
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"git.jojii.de/jojii/ZimWiki/zim"
+	"github.com/JojiiOfficial/ZimWiki/zim"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"git.jojii.de/jojii/zimserver/zim"
+	"git.jojii.de/jojii/ZimWiki/zim"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/router.go
+++ b/router.go
@@ -9,8 +9,8 @@ import (
 	"net/http/pprof"
 	_ "net/http/pprof"
 
-	"git.jojii.de/jojii/zimserver/handlers"
-	"git.jojii.de/jojii/zimserver/zim"
+	"git.jojii.de/jojii/ZimWiki/handlers"
+	"git.jojii.de/jojii/ZimWiki/zim"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 )

--- a/router.go
+++ b/router.go
@@ -9,8 +9,8 @@ import (
 	"net/http/pprof"
 	_ "net/http/pprof"
 
-	"git.jojii.de/jojii/ZimWiki/handlers"
-	"git.jojii.de/jojii/ZimWiki/zim"
+	"github.com/JojiiOfficial/ZimWiki/handlers"
+	"github.com/JojiiOfficial/ZimWiki/zim"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
The project is called ZimWiki but in some files it is called zimserver...
This is now corrected!