### PR TITLE
Embed templates and assets into the binary

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+          go-version: '1.16.8'
     - name: Build
       run: |
-        go build -o main
+        make build

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 replace github.com/tim-st/go-zim v0.1.2 => github.com/JojiiOfficial/go-zim v0.1.2-1
 
 require (
-	github.com/JojiiOfficial/gaw v1.2.8
 	github.com/agext/levenshtein v1.2.3
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/JojiiOfficial/ZimWiki
 
-go 1.14
+go 1.16
 
 replace github.com/tim-st/go-zim v0.1.2 => github.com/JojiiOfficial/go-zim v0.1.2-1
 

--- a/handlers/asset.go
+++ b/handlers/asset.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/JojiiOfficial/gaw"
 	"github.com/gorilla/mux"
 )
 
@@ -23,12 +22,6 @@ func Assets(w http.ResponseWriter, r *http.Request, hd HandlerData) error {
 
 	// Get local path
 	path := filepath.Clean(path.Join(AssetsPath, assetType, reqFile))
-
-	// Check if file exists
-	if !gaw.FileExists(path) {
-		http.NotFound(w, r)
-		return nil
-	}
 
 	// Serve Asset
 	return serveRawFile(path, w)

--- a/handlers/template.go
+++ b/handlers/template.go
@@ -6,8 +6,11 @@ import (
 	"path"
 	"time"
 	"strings"
+	"embed"
 	"github.com/chai2010/gettext-go"
 )
+
+var WebFS embed.FS
 
 var (
 	// TemplateCache is a cache of templates
@@ -111,7 +114,7 @@ func serveTemplate(tmpFile string, w http.ResponseWriter, r *http.Request, btd T
 
 	if !has {
 		// Parse if not in cache
-		tmpl, err = template.New(tmplName).Funcs(funcMap).ParseFiles(BaseTemplate, tmpFile)
+		tmpl, err = template.New(tmplName).Funcs(funcMap).ParseFS(WebFS, BaseTemplate, tmpFile)
 		if err != nil {
 			return err
 		}

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"os"
 	"strings"
 )
 
@@ -22,7 +21,7 @@ func serveRawFile(path string, w http.ResponseWriter) error {
 
 func serveStaticFile(path string, w io.Writer) error {
 	// Try to open file
-	f, err := os.OpenFile(path, os.O_RDONLY, 0600)
+	f, err := WebFS.Open(path)
 	defer f.Close()
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -8,11 +8,16 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	"embed"
 
+	"github.com/JojiiOfficial/ZimWiki/handlers"
 	"github.com/JojiiOfficial/ZimWiki/zim"
 	log "github.com/sirupsen/logrus"
 	"github.com/pelletier/go-toml"
 )
+
+//go:embed html/*
+var WebFS embed.FS
 
 type configStruct struct {
 	libPath  string
@@ -21,6 +26,8 @@ type configStruct struct {
 
 func main() {
 	setupLogger()
+
+	handlers.WebFS = WebFS
 
 	// Default configuration of ZimWiki
 	defaultConfig, _ := toml.Load(`


### PR DESCRIPTION
Since Go 1.16, with the package ```embed```, it's possible to access to files embedded in the running Go program.
With this PR, the ZimWiki executable becomes truly portable, and no longer requires an ```html``` folder to function.
What are your thoughts on this?