### PR TITLE
Caching of search results for smoother navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ endif
 
 clean:
 	go clean
+	go mod tidy
 	rm -f ZimWiki.1
 	rm -f ZimWiki
 	rm -f main

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ config.toml:
 [Config]
 LibraryPath = "./library"
 Address = ":8080"
+EnableSearchCache = "true"
+SearchCacheDuration = "2"
 ```
 
 # Usage
@@ -53,6 +55,7 @@ Run the binary and go to `https://localhost:Port`
 - [x] Read Wikis
 - [x] Search (inside a wiki or globally)
 - [x] Create wiki index files for faster search
+- [x] Caching of search results for smoother navigation
 - [x] Send content gzipped
 - [x] Use symlinks as .zim link
 - [x] Replace absolute links with relative ones

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,10 @@ require (
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/gorilla/mux v1.8.0
 	github.com/klauspost/compress v1.13.6
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tim-st/go-zim v0.1.4
-	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
+	golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/chai2010/gettext-go v1.0.2
 	github.com/gorilla/mux v1.8.0
 	github.com/klauspost/compress v1.13.6
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tim-st/go-zim v0.1.4
 	golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 // indirect
+	zgo.at/zcache v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -35,6 +37,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 h1:QOQNt6vCjMpXE7JSK5VvAzJC1byuN3FgTNSBwf+CJgI=
+golang.org/x/sys v0.0.0-20210925032602-92d5a993a665/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -40,3 +38,5 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210925032602-92d5a993a665 h1:QOQNt6vCjMpXE7JSK5VvAzJC1byuN3FgTNSBwf+CJgI=
 golang.org/x/sys v0.0.0-20210925032602-92d5a993a665/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+zgo.at/zcache v1.0.0 h1:jeQ/2ZHw76P4acf7LqFKJeil8NVyAY+bDrvKwq4XTjI=
+zgo.at/zcache v1.0.0/go.mod h1:xWQo2ha/bamTmx8CbfrZl9Nf8AoT5uNh2hWfbQi8TiE=

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	version string
-    buildTime string
+	version   string
+	buildTime string
 )
 
 // Index handle index route

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -16,6 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var EnableSearchCache bool
+
 // Cache initialization with a default expiration time of 2 minutes and purge expired items every 2 minutes
 var searchCache = cache.New(2*time.Minute, 2*time.Minute)
 
@@ -28,7 +30,7 @@ func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zi
 	cachedData, found := searchCache.Get(query + wiki.Path)
 
 	// If not cached
-	if !found {
+	if !found || !EnableSearchCache {
 		// Search entries
 		entries = wiki.SearchForEntry(query)
 		// Sort them by similarity
@@ -80,7 +82,7 @@ func searchGlobal(query string, nbResultsPerPage int, resultsUntil int, handler 
 	// Check if the search is cached
 	cachedData, found := searchCache.Get(query)
 
-	if !found {
+	if !found || !EnableSearchCache {
 		mx := sync.Mutex{}
 		wg := sync.WaitGroup{}
 		files := handler.GetFiles()

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/JojiiOfficial/ZimWiki/zim"
 	"github.com/gorilla/mux"
-	"github.com/patrickmn/go-cache"
+	"zgo.at/zcache"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -20,7 +20,7 @@ var (
 	EnableSearchCache   bool
 	SearchCacheDuration int
 	// Cache initialization with a default expiration time of X minutes and purge expired items every X minutes
-	searchCache = cache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)
+	searchCache = zcache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)
 )
 
 func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zim.File) ([]zim.SRes, int, int, bool) {
@@ -38,11 +38,12 @@ func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zi
 		// Sort them by similarity
 		sort.Sort(sort.Reverse(zim.ByPercentage(entries)))
 		// Cache the search with the default expiration time
-		searchCache.Set(query+wiki.Path, entries, cache.DefaultExpiration)
+		searchCache.Set(query+wiki.Path, entries, zcache.DefaultExpiration)
 		isCached = false
 	} else {
 		// Otherwise the variable entries retrieves the content of the variable cachedData
 		entries = cachedData.([]zim.SRes)
+		searchCache.Touch(query+wiki.Path, zcache.DefaultExpiration)
 		isCached = true
 	}
 
@@ -111,7 +112,7 @@ func searchGlobal(query string, nbResultsPerPage int, resultsUntil int, handler 
 		// Sort by similarity
 		sort.Sort(sort.Reverse(zim.ByPercentage(results)))
 		// Cache the search with the default expiration time
-		searchCache.Set(query, results, cache.DefaultExpiration)
+		searchCache.Set(query, results, zcache.DefaultExpiration)
 		isCached = false
 	} else {
 		// Otherwise the variable results retrieves the content of the variable cachedData

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -16,8 +16,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var EnableSearchCache bool
-var SearchCacheDuration int
+var (
+	EnableSearchCache   bool
+	SearchCacheDuration int
+)
 
 // Cache initialization with a default expiration time of 2 minutes and purge expired items every 2 minutes
 var searchCache = cache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -17,9 +17,10 @@ import (
 )
 
 var EnableSearchCache bool
+var SearchCacheDuration int
 
 // Cache initialization with a default expiration time of 2 minutes and purge expired items every 2 minutes
-var searchCache = cache.New(2*time.Minute, 2*time.Minute)
+var searchCache = cache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)
 
 func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zim.File) ([]zim.SRes, int, int, bool) {
 	var entries []zim.SRes

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -19,10 +19,9 @@ import (
 var (
 	EnableSearchCache   bool
 	SearchCacheDuration int
+	// Cache initialization with a default expiration time of X minutes and purge expired items every X minutes
+	searchCache = cache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)
 )
-
-// Cache initialization with a default expiration time of 2 minutes and purge expired items every 2 minutes
-var searchCache = cache.New(time.Duration(SearchCacheDuration)*time.Minute, time.Duration(SearchCacheDuration)*time.Minute)
 
 func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zim.File) ([]zim.SRes, int, int, bool) {
 	var entries []zim.SRes

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -20,7 +20,6 @@ import (
 var searchCache = cache.New(2*time.Minute, 2*time.Minute)
 
 func searchSingle(query string, nbResultsPerPage int, resultsUntil int, wiki *zim.File) ([]zim.SRes, int, int, bool) {
-
 	var entries []zim.SRes
 
 	var isCached bool

--- a/handlers/template.go
+++ b/handlers/template.go
@@ -1,21 +1,21 @@
 package handlers
 
 import (
+	"embed"
 	"html/template"
 	"net/http"
 	"path"
-	"time"
 	"strings"
-	"embed"
+	"time"
+
 	"github.com/chai2010/gettext-go"
 )
-
-var WebFS embed.FS
-var LocaleByte []byte
 
 var (
 	// TemplateCache is a cache of templates
 	TemplateCache = make(map[string]*template.Template)
+	WebFS         embed.FS
+	LocaleByte    []byte
 )
 
 // 						      //
@@ -24,10 +24,10 @@ var (
 
 // TemplateData data for the base template
 type TemplateData struct {
-	Favtype      string
-	FavIcon      string
-	Wiki         string
-	Namespace    string
+	Favtype   string
+	FavIcon   string
+	Wiki      string
+	Namespace string
 
 	HomeTemplateData
 	WikiViewTemplateData
@@ -46,9 +46,9 @@ type HomeCards struct {
 // HomeTemplateData contain data
 // for the home template
 type HomeTemplateData struct {
-	Cards       []HomeCards
-	Version     string
-	BuildTime   string
+	Cards     []HomeCards
+	Version   string
+	BuildTime string
 }
 
 // WikiViewTemplateData data for wiki view page

--- a/main.go
+++ b/main.go
@@ -24,9 +24,10 @@ var WebFS embed.FS
 var LocaleByte []byte
 
 type configStruct struct {
-	libPath           string
-	address           string
-	EnableSearchCache bool
+	libPath             string
+	address             string
+	EnableSearchCache   bool
+	SearchCacheDuration int
 }
 
 func main() {
@@ -41,12 +42,14 @@ func main() {
 	[Config]
 	LibraryPath = "./library"
 	Address = ":8080"
-	EnableSearchCache = "true"`)
+	EnableSearchCache = "true"
+	SearchCacheDuration = "2"`)
 
 	// Load default configuration
 	libPath := defaultConfig.Get("Config.LibraryPath").(string)
 	address := defaultConfig.Get("Config.Address").(string)
 	EnableSearchCache, _ := strconv.ParseBool(defaultConfig.Get("Config.EnableSearchCache").(string))
+	SearchCacheDuration, _ := strconv.Atoi(defaultConfig.Get("Config.SearchCacheDuration").(string))
 
 	// Load configuration file
 	configData, err := toml.LoadFile("config.toml")
@@ -58,13 +61,15 @@ func main() {
 		libPath = configDataTree.Get("LibraryPath").(string)
 		address = configDataTree.Get("Address").(string)
 		EnableSearchCache, _ = strconv.ParseBool(configDataTree.Get("Config.EnableSearchCache").(string))
+		SearchCacheDuration, _ = strconv.Atoi((configDataTree.Get("Config.SearchCacheDuration")).(string))
 	} else {
 		log.Error("Config.toml not found, default configuration will be used.")
 	}
 
-	config := configStruct{libPath: libPath, address: address, EnableSearchCache: EnableSearchCache}
+	config := configStruct{libPath: libPath, address: address, EnableSearchCache: EnableSearchCache, SearchCacheDuration: SearchCacheDuration}
 
 	handlers.EnableSearchCache = EnableSearchCache
+	handlers.SearchCacheDuration = SearchCacheDuration
 
 	if len(os.Args) > 1 {
 		config.libPath = os.Args[1]

--- a/main.go
+++ b/main.go
@@ -17,11 +17,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//go:embed html/*
-var WebFS embed.FS
+var (
+	//go:embed html/*
+	WebFS embed.FS
 
-//go:embed locale.zip
-var LocaleByte []byte
+	//go:embed locale.zip
+	LocaleByte []byte
+)
 
 type configStruct struct {
 	libPath             string


### PR DESCRIPTION
This new PR features the ability to cache search results for a period of time, for a smoother navigation.
This can be configured from the `config.toml` configuration file.
What are your thoughts on this? :)